### PR TITLE
support for nested shadow dom added

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -1,5 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair */
-/* eslint-disable no-console */
 /* @flow */
 /* eslint max-lines: off */
 import { v4 as uuidv4 } from 'uuid';
@@ -1113,14 +1111,15 @@ export function getRootNode(element : Node) : Node {
 }
 
 export function insertShadowSlot(element : HTMLElement, styles? : HTMLElement) : HTMLElement {
-    // const DEFAULT_STYLESHEET_INDEX = 0;
-    // $FlowFixMe
-    let styleNode = getRootNode(element).querySelector('style');
+    const DEFAULT_STYLESHEET_INDEX = 0;
     const shadowHost = getShadowHost(element);
 
     if (!shadowHost) {
         throw new Error(`Element is not in shadow dom`);
     }
+
+    // $FlowFixMe
+    let styleNode = getRootNode(element).querySelector('style');
 
     const slotName = `shadow-slot-${  uuidv4() }`;
     const slot = document.createElement('slot');
@@ -1132,18 +1131,18 @@ export function insertShadowSlot(element : HTMLElement, styles? : HTMLElement) :
     shadowHost.appendChild(slotProvider);
 
     if (styles) {
-        console.log('styles are');
-        console.log(styles);
         if (!styleNode) {
             styleNode = document.createElement('style');
             element.appendChild(styleNode);
         }
     
-        // styleNode.sheet?.insertRule(
-        //     `::slotted([slot="${  slotName  }"]) { ${  styles  } }`, DEFAULT_STYLESHEET_INDEX
-        // );
+        // $FlowFixMe
+        const cssRule = `::slotted([slot="${  slotName  }"]) { ${  styles  } }`;
+        
+        if (styleNode.sheet) {
+            styleNode.sheet.insertRule(cssRule, DEFAULT_STYLESHEET_INDEX);
+        }
     }
-
 
     if (isShadowElement(shadowHost)) {
         return insertShadowSlot(slotProvider, styles);

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,6 +1,8 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable no-console */
 /* @flow */
 /* eslint max-lines: off */
-
+import { v4 as uuidv4 } from 'uuid';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { linkFrameWindow, isWindowClosed, assertSameDomain,
     type SameDomainWindowType, type CrossDomainWindowType } from 'cross-domain-utils/src';
@@ -1101,26 +1103,51 @@ export function getShadowHost(element : Node) : ?HTMLElement {
     }
 }
 
-export function insertShadowSlot(element : HTMLElement) : HTMLElement {
+  
+export function getRootNode(element : Node) : Node {
+    while (element.parentNode) {
+        element = element.parentNode;
+    }
+  
+    return element;
+}
+
+export function insertShadowSlot(element : HTMLElement, styles? : HTMLElement) : HTMLElement {
+    // const DEFAULT_STYLESHEET_INDEX = 0;
+    // $FlowFixMe
+    let styleNode = getRootNode(element).querySelector('style');
     const shadowHost = getShadowHost(element);
 
     if (!shadowHost) {
         throw new Error(`Element is not in shadow dom`);
     }
 
-    if (isShadowElement(shadowHost)) {
-        throw new Error(`Host element is also in shadow dom`);
-    }
-
-    const slotName = `shadow-slot-${ uniqueID() }`;
-
+    const slotName = `shadow-slot-${  uuidv4() }`;
     const slot = document.createElement('slot');
     slot.setAttribute('name', slotName);
     element.appendChild(slot);
-    
+
     const slotProvider = document.createElement('div');
     slotProvider.setAttribute('slot', slotName);
     shadowHost.appendChild(slotProvider);
+
+    if (styles) {
+        console.log('styles are');
+        console.log(styles);
+        if (!styleNode) {
+            styleNode = document.createElement('style');
+            element.appendChild(styleNode);
+        }
+    
+        // styleNode.sheet?.insertRule(
+        //     `::slotted([slot="${  slotName  }"]) { ${  styles  } }`, DEFAULT_STYLESHEET_INDEX
+        // );
+    }
+
+
+    if (isShadowElement(shadowHost)) {
+        return insertShadowSlot(slotProvider, styles);
+    }
 
     return slotProvider;
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,6 +1,5 @@
 /* @flow */
 /* eslint max-lines: off */
-import { v4 as uuidv4 } from 'uuid';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { linkFrameWindow, isWindowClosed, assertSameDomain,
     type SameDomainWindowType, type CrossDomainWindowType } from 'cross-domain-utils/src';
@@ -1121,7 +1120,7 @@ export function insertShadowSlot(element : HTMLElement, styles? : HTMLElement) :
     // $FlowFixMe
     let styleNode = getRootNode(element).querySelector('style');
 
-    const slotName = `shadow-slot-${  uuidv4() }`;
+    const slotName = `shadow-slot-${ uniqueID() }`;
     const slot = document.createElement('slot');
     slot.setAttribute('name', slotName);
     element.appendChild(slot);
@@ -1136,8 +1135,7 @@ export function insertShadowSlot(element : HTMLElement, styles? : HTMLElement) :
             element.appendChild(styleNode);
         }
     
-        // $FlowFixMe
-        const cssRule = `::slotted([slot="${  slotName  }"]) { ${  styles  } }`;
+        const cssRule = `::slotted([slot="${  slotName  }"]) { ${  styles.toString()  } }`;
         
         if (styleNode.sheet) {
             styleNode.sheet.insertRule(cssRule, DEFAULT_STYLESHEET_INDEX);

--- a/test/tests/dom/shadowDOMFunctions.js
+++ b/test/tests/dom/shadowDOMFunctions.js
@@ -35,13 +35,15 @@ describe('Web components', () => {
         if (!document?.body) {
             throw new Error('Body not found');
         }
+        
+        const customElement = document.createElement('custom-web-component');
 
         // Clean the DOM
-        document.body.innerHTML = '';
+        if (document.body) {
+            document.body.innerHTML = '';
+            document.body.appendChild(customElement);
+        }
 
-        const customElement = document.createElement('custom-web-component');
-        // $FlowFixMe
-        document.body.appendChild(customElement);
     
         if (!customElement || !customElement.shadowRoot) {
             throw new Error('custom element does not have shadow root');
@@ -164,12 +166,20 @@ describe('Web components', () => {
             const innerSpan = document.createElement('span');
             innerSpan.setAttribute('id', 'inner-span');
             
-            // $FlowFixMe
-            customComponent.shadowRoot.appendChild(innerSpan);
-            // $FlowFixMe
-            customWrapper.shadowRoot.appendChild(customComponent);
-            // $FlowFixMe
-            document.body.appendChild(customWrapper);
+            const customComponentShadowRoot = customComponent.shadowRoot;
+            const customWrapperShadowRoot = customWrapper.shadowRoot;
+            
+            if (customComponentShadowRoot) {
+                customComponentShadowRoot.appendChild(innerSpan);
+            }
+
+            if (customWrapperShadowRoot) {
+                customWrapperShadowRoot.appendChild(customComponent);
+            }
+
+            if (document.body) {
+                document.body.appendChild(customWrapper);
+            }
 
             /**
              * At this point the HTML structure looks like this:

--- a/test/tests/dom/shadowDOMFunctions.js
+++ b/test/tests/dom/shadowDOMFunctions.js
@@ -1,5 +1,4 @@
 /* @flow */
-
 import { isShadowElement, getShadowRoot, getShadowHost, insertShadowSlot } from '../../../src';
 
 // This component is needed for testing the case when shadowRoot and shadowDOM are the same
@@ -136,8 +135,25 @@ describe('Web components', () => {
     
         });
     
-        it('should throw exception if Host element is also in shadow dom', () => {
+        it('should return slotProvider ', () => {
+            const innerElement = document.querySelector('custom-web-component')?.shadowRoot?.querySelector('#inner-span');
+            
+            if (!innerElement) {
+                throw new Error('unable to find inner element');
+            }
     
+            const result = insertShadowSlot(innerElement);
+    
+            if (!result) {
+                throw new Error('should have returned an element, got undefined');
+            }
+    
+            if (!result?.getAttribute('slot')?.match(/shadow-slot-/i)) {
+                throw new Error('should have returned a valid slot element');
+            }
+        });
+
+        it('should return a nested slotProvider ', () => {
             // TestCase components setup
             const customWrapper = document.createElement('custom-wrapper');
             customWrapper.setAttribute('id', 'custom-wrapper-id');
@@ -152,7 +168,6 @@ describe('Web components', () => {
             customComponent.shadowRoot.appendChild(innerSpan);
             // $FlowFixMe
             customWrapper.shadowRoot.appendChild(customComponent);
-            
             // $FlowFixMe
             document.body.appendChild(customWrapper);
 
@@ -169,35 +184,14 @@ describe('Web components', () => {
              *    </custom-wrapper>
              * </html>
              */
-             
-            let insertShadowSlotError = '';
 
-            try {
-                insertShadowSlot(innerSpan);
-            } catch (error) {
-                insertShadowSlotError = error?.message;
-            }
+            const slotProvider =  insertShadowSlot(innerSpan);
 
-            if (!insertShadowSlotError.match(/Host element is also in shadow dom/)) {
-                throw new Error(`should have thrown 'Host element is also in shadow dom' exception, got '${ insertShadowSlotError }'`);
-            }
-        });
-    
-    
-        it('should return slotProvider ', () => {
-            const innerElement = document.querySelector('custom-web-component')?.shadowRoot?.querySelector('#inner-span');
-            
-            if (!innerElement) {
-                throw new Error('unable to find inner element');
-            }
-    
-            const result = insertShadowSlot(innerElement);
-    
-            if (!result) {
+            if (!slotProvider) {
                 throw new Error('should have returned an element, got undefined');
             }
     
-            if (!result?.getAttribute('slot')?.match(/shadow-slot-/i)) {
+            if (!slotProvider?.getAttribute('slot')?.match(/shadow-slot-/i)) {
                 throw new Error('should have returned a valid slot element');
             }
         });


### PR DESCRIPTION
# Description

- Added support for `insertShadowSlot` function with nested web components
- Part of the solution comes is based on [this implementation](https://github.com/braintree/braintree-web/blob/b86db352fb3e08a049d866e8a07197c43cbb0374/src/lib/shadow.js#L25) from https://github.com/braintree/braintree-web
